### PR TITLE
Show instances has public ip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .envrc
 cmd/omssh/omssh
+bin/*

--- a/cmd/omssh/main.go
+++ b/cmd/omssh/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	version            = "0.0.1"
+	version            = "0.0.2"
 	defUser            = "ubuntu"
 	defCredentialsPath = "~/.aws/credentials"
 )

--- a/ec2.go
+++ b/ec2.go
@@ -55,18 +55,18 @@ func (d *EC2Client) GetEC2List() ([]EC2Info, error) {
 	for _, r := range res.Reservations {
 		for _, i := range r.Instances {
 
+			// public ip address
+			if i.PublicIpAddress == nil {
+				continue
+			}
+			publicIPAddress := *i.PublicIpAddress
+
 			// tag:Name
 			name := ""
 			for _, t := range i.Tags {
 				if *t.Key == "Name" {
 					name = *t.Value
 				}
-			}
-
-			// public ip address
-			publicIPAddress := ""
-			if i.PublicIpAddress != nil {
-				publicIPAddress = *i.PublicIpAddress
 			}
 
 			// private ip address


### PR DESCRIPTION
EC2 instance connect provides ssh to ec2 intances on public subnet.
So omssh show information of ec2 instances which has public ip.

EC2 instances which has public ip are always on public subnet.
But selection objects are narrowed.